### PR TITLE
fix: Use `Args[0]`  instead of hardcoded one

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,12 +3,13 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "SwitchTube-Downloader",
+	Use:   filepath.Base(os.Args[0]),
 	Short: "A CLI downloader for SwitchTube videos",
 
 	CompletionOptions: cobra.CompletionOptions{


### PR DESCRIPTION
This is a more generic approach and also fixes an issue on arch, where the executable installed by AUR is called `swdl` and therefore wouldn't match the name in the help page